### PR TITLE
Fix shebang, copy to path directly.

### DIFF
--- a/rawzica.py
+++ b/rawzica.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python3
 # coding: utf-8
-#!/usr/bin/env python
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,6 @@ import os
 import sys
 from shutil import copy
 
-if sys.version_info.major < 3:
-    raise RuntimeError('Need Python 3 (or later) for rawzica!')
-
 from setuptools import setup, find_packages
 from rawzica import __version__
 
@@ -18,9 +15,6 @@ setup(
     install_requires=(
     ),
     entry_points={
-        'console_scripts': (
-            'rawzica=rawzica:main'
-        ),
     },
     data_files=(
         ('/etc/cron.daily/', ['rawzica']),
@@ -30,3 +24,6 @@ setup(
 ETC_FILE = 'rawzica.conf'
 if not os.path.exists('/etc/' + ETC_FILE):
     copy(os.path.join(__file__, ETC_FILE), '/etc/')
+
+setup_path = os.path.dirname(__file__)
+copy(os.path.join(setup_path, 'rawzica.py'), '/usr/local/bin/rawzica')


### PR DESCRIPTION
Use python3 by default, and avoid version checking in setup.py. Use python script directly instead of creating new entry point to simplify deployment.